### PR TITLE
docs: fix release download command to resolve the versioned asset name

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,17 +158,29 @@ Download the archive for your platform from the
 [**Releases page**](https://github.com/sunix/jdtls-mcp/releases/latest),
 extract it, and you're ready to go — no build step required.
 
+Release assets are named with their version tag (e.g.
+`jdtls-mcp-v1.0.1-linux-x86_64.tar.gz`), so `releases/latest/download/<name>`
+only works if you hardcode the current version. Resolve it first instead:
+
 ```bash
+# Resolve the latest version tag once
+VERSION=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+  https://github.com/sunix/jdtls-mcp/releases/latest | sed 's#.*/tag/##')
+
 # Linux x86_64
-curl -L https://github.com/sunix/jdtls-mcp/releases/latest/download/jdtls-mcp-linux-x86_64.tar.gz \
+curl -L "https://github.com/sunix/jdtls-mcp/releases/download/${VERSION}/jdtls-mcp-${VERSION}-linux-x86_64.tar.gz" \
   | tar xz
 cd jdtls-mcp
 
 # macOS arm64 (Apple Silicon)
-curl -L https://github.com/sunix/jdtls-mcp/releases/latest/download/jdtls-mcp-macos-aarch64.tar.gz \
+curl -L "https://github.com/sunix/jdtls-mcp/releases/download/${VERSION}/jdtls-mcp-${VERSION}-macos-aarch64.tar.gz" \
   | tar xz
 cd jdtls-mcp
 ```
+
+Other platforms follow the same `jdtls-mcp-${VERSION}-<platform>.<ext>` naming
+— see the [Releases page](https://github.com/sunix/jdtls-mcp/releases/latest)
+for the full list of assets.
 
 The extracted directory contains `plugins/`, `configuration/`, and `scripts/`.
 


### PR DESCRIPTION
Fixes #17

The README's "Option A — Download a release" command hardcodes an
unversioned asset filename:

```
curl -L https://github.com/sunix/jdtls-mcp/releases/latest/download/jdtls-mcp-linux-x86_64.tar.gz
```

Published assets are version-prefixed (e.g. `jdtls-mcp-v1.0.1-linux-x86_64.tar.gz`),
so this 404s under `-L` alone (silently under `-fsSL`), and anyone following
the "recommended" install path falls straight through to a full source build.

`scripts/download-and-start.sh` already resolves the current tag correctly
via the GitHub API before building the download URL — this PR makes the
README do the same (via the simpler `releases/latest` redirect, since a
one-liner doesn't need the full API-based error handling that script has),
so the documented command actually works again.

## Test plan
- [x] Verified the current README command 404s against the live releases API
- [x] Verified the new two-step command resolves `v1.0.1` and downloads
      `jdtls-mcp-v1.0.1-linux-x86_64.tar.gz` successfully (HTTP 200)
- [x] Confirmed the extracted archive still lands in a `jdtls-mcp/` directory
      regardless of version, so the following `cd jdtls-mcp` stays correct