### PR TITLE
docs: document the java_workspace_status tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ existing tools.
 | `java_document_symbols` | List all symbols in a file |
 | `java_workspace_symbols` | Search for symbols across the workspace |
 | `java_diagnostics` | Get compilation errors and warnings for a file or workspace |
+| `java_workspace_status` | Report jdtls workspace readiness — project import progress, build status, index readiness, and classpath/Maven dependency errors. Call before other tools to check the workspace is ready, or to diagnose dependency-resolution failures |
 
 All position-based tools use **0-based** line and character offsets (LSP convention).
 


### PR DESCRIPTION
Fixes #18

`tools/list` reports 8 tools; the README's "Available MCP tools" table only
documented 7. `java_workspace_status` was added in #11 but the table was
never updated.

Description matches the tool's actual registered description in
`JdtlsMcpTools.java`, condensed to match the table's one-line style used by
the other rows.

## Test plan
- [x] Confirmed via a live `tools/list` call that the server exposes exactly
      these 8 tools, matching the table after this change