### PR TITLE
fix: check Java version before launching, not after

### DIFF
--- a/scripts/start-mcp-server.sh
+++ b/scripts/start-mcp-server.sh
@@ -59,6 +59,18 @@ for _jh in "${JAVA_HOME_21_X64:-}" "${JAVA_HOME_21_ARM64:-}" "${JAVA_HOME:-}"; d
 done
 echo "  java      : $JAVA_CMD" >&2
 
+# ---- Verify Java 21+ --------------------------------------------------------
+# Without this check, a stale default `java` on PATH (with none of the
+# JAVA_HOME* vars above set) fails deep inside the OSGi launcher with a much
+# less helpful error than a clear version mismatch message.
+JAVA_MAJOR="$("$JAVA_CMD" -version 2>&1 | head -1 | grep -oE '"[0-9]+' | tr -d '"')"
+if [[ -z "$JAVA_MAJOR" || "$JAVA_MAJOR" -lt 21 ]]; then
+  echo "ERROR: jdtls-mcp requires Java 21+, found ${JAVA_MAJOR:-an unrecognised version} at $JAVA_CMD" >&2
+  echo "       Set JAVA_HOME (or JAVA_HOME_21_X64 / JAVA_HOME_21_ARM64) to a Java 21+" >&2
+  echo "       install and re-run — e.g. 'sdk use java 21' if using SDKMAN." >&2
+  exit 1
+fi
+
 # ---- Arguments ------------------------------------------------------------
 WORKSPACE="${1:-$REPO_DIR/test-workspace/hello-jdtls}"
 DATA_DIR="${2:-/tmp/jdtls-mcp-data}"


### PR DESCRIPTION
Fixes #20

`start-mcp-server.sh`'s Java resolution only checks `JAVA_HOME_21_X64`,
`JAVA_HOME_21_ARM64`, and `JAVA_HOME`, then falls back to plain `java` on
`PATH` with no version check. On a machine where the default `java` is <21
and none of those env vars are set, the script proceeded straight to `exec`
and failed deep inside the OSGi launcher — a much less helpful error than a
clear version mismatch.

Adds a check right after `JAVA_CMD` is resolved: parses the major version
from `$JAVA_CMD -version` and fails with a clear message pointing at how to
fix it (set `JAVA_HOME`, or `sdk use java 21`) instead of proceeding.

## Test plan
- [x] Forced `PATH` to only contain a Java 11 install with no `JAVA_HOME*`
      vars set — script now fails immediately with:
      `ERROR: jdtls-mcp requires Java 21+, found 11 at java` (exit 1),
      instead of failing inside the OSGi launcher
- [x] Confirmed the happy path is unaffected — full install + protocol smoke
      test (`initialize` + `tools/list`) still passes with Java 25 selected